### PR TITLE
Support v3.10.0 - the first version supports Apple M1

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -56,6 +56,8 @@ get_arch() {
         arch="amd64"
     elif [ "$(uname -m)" = "aarch64" ]; then
         arch="arm"
+    elif [ "$(uname -m)" = "arm64" ]; then
+        arch="arm64"
     else
         arch="386"
     fi

--- a/bin/list-all
+++ b/bin/list-all
@@ -18,7 +18,7 @@ list-all() {
         # Fallback when token is not set
         local tags_path="https://github.com/${github_repo}/tags"
         cmd="${cmd} ${tags_path}"
-        versions=$(eval "${cmd}" | grep -E -o "/hairyhenderson/gomplate/releases/tag/v[0-9].[0-9].[0-9][0-9]?" | awk -F '/' '{ print $6 }' | sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n -u | tr '\n' ' ')
+        versions=$(eval "${cmd}" | grep -E -o "/hairyhenderson/gomplate/releases/tag/v[0-9].[0-9]+.[0-9][0-9]?" | awk -F '/' '{ print $6 }' | sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n -u | tr '\n' ' ')
     fi
 
     echo "${versions}"


### PR DESCRIPTION
Hi, I roughly fixed the version listing and `arm64` platform detection.
At least the Apple M1 users can install the latest `arm64` ready version `v3.10.0`.

refs: https://github.com/hairyhenderson/gomplate/releases/tag/v3.10.0

### Known issue:

If Apple M1 users want to install the `x86_64` version before `v3.10.0`, they have to run `asdf` with `arch`:

```
arch -x86_64 asdf install gomplate v3.9.0
```

Just like I did on my M1 previously.