### PR TITLE
Fix Arch download for ARM 32 and 64

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -55,9 +55,11 @@ get_arch() {
     if [ "$(uname -m)" = "x86_64" ]; then
         arch="amd64"
     elif [ "$(uname -m)" = "aarch64" ]; then
-        arch="arm"
+        arch="arm64"
     elif [ "$(uname -m)" = "arm64" ]; then
         arch="arm64"
+    elif [ "$(uname -m)" = "armv7l" ]; then
+        arch="armv7"
     else
         arch="386"
     fi


### PR DESCRIPTION
Tested the results of `uname -m` on AWS ARM64 also looking around https://stackoverflow.com/questions/31851611/differences-between-arm64-and-aarch64

Looking at https://github.com/hairyhenderson/gomplate/releases the file names have changed