### PR TITLE
fix: add always v prefix to release URL

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -83,7 +83,7 @@ get_download_url() {
 
     local github_repo="hairyhenderson/gomplate"
 
-    echo "https://github.com/${github_repo}/releases/download/${version}/${filename}"
+    echo "https://github.com/${github_repo}/releases/download/v${version#v}/${filename}"
 }
 
 tmp_download_dir="$(mktemp -d -t 'asdf_XXXXXXXX')"


### PR DESCRIPTION
Latest gomplate version is listed without `v` prefix. It causes the `install.sh` script to fail finding the correct gomplate release artifact.

Related issue #4.